### PR TITLE
Add browser-based traffic simulation prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,77 @@
-# traffic_sim
+# Traffic Simulation Application
+
+An interactive traffic simulation prototype that overlays real-world road geometry on an OpenStreetMap base layer. Users can inject vehicles, place roadblocks, and control the simulation lifecycle entirely from the browser while a lightweight Python server delivers the single-page experience.
+
+## Features
+
+- **Dynamic overlay** – Real road segments are requested from the Overpass API when the simulation starts and only when the user is sufficiently zoomed in.
+- **Precise interactions** – Left-click to spawn configurable numbers of vehicles, right-click to drop full-blocking barriers on the highlighted segment.
+- **Vehicle behaviours** – Vehicles inherit color and speed from a JSON configuration file, traverse connected roads, and exit the simulation when they leave the viewport.
+- **Automatic halting** – The simulation pauses automatically when all vehicles have exited or every car is blocked behind road barriers.
+- **Responsive UI** – Run/Resume, Pause, and Stop controls keep the map viewport frozen during simulation and provide toast feedback for user actions.
+
+## Getting Started
+
+### Requirements
+
+- Python 3.11+
+- No third-party Python packages required.
+
+### Running the application
+
+```bash
+python -m app.main
+```
+
+This starts a local development server at `http://127.0.0.1:5000/` using Python's built-in WSGI utilities.
+
+### Running tests
+
+```bash
+pytest
+```
+
+### Usage Tips
+
+1. Pan/zoom to your area of interest and zoom in until the on-screen prompt disappears (visible radius ≤ 5 miles).
+2. Click **Run** to lock the viewport and load the current road network.
+3. Left-click a highlighted segment to add vehicles; right-click to place a red block that stops traffic.
+4. Use the car count input to control how many vehicles spawn per click.
+5. Hit **Pause** to temporarily halt vehicle movement or **Stop** to end the run while keeping overlays visible.
+
+> **Note:** Road data is retrieved from the public Overpass API; ensure you have an active internet connection when starting the simulation.
+
+## Project Structure
+
+```
+app/
+  __init__.py
+  main.py
+  templates/
+    index.html
+  static/
+    css/styles.css
+    config/vehicleTypes.json
+    js/
+      main.js
+      mapViewer.js
+      overlayManager.js
+      interactionHandler.js
+      simController.js
+      vehicleConfig.js
+      vehicleEngine.js
+      uiControls.js
+      utils/
+        geoUtils.js
+        logger.js
+requirements.txt
+README.md
+```
+
+## Configuration
+
+Vehicle types, colors, and speeds are configured in `app/static/config/vehicleTypes.json`. Update or extend the entries to experiment with different fleets without touching the code.
+
+## License
+
+MIT

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Tuple
+from urllib.parse import unquote
+from wsgiref.simple_server import make_server
+
+_STATUS_MAP = {
+    200: "OK",
+    404: "Not Found",
+    405: "Method Not Allowed",
+}
+
+_MIME_MAP = {
+    ".html": "text/html; charset=utf-8",
+    ".css": "text/css; charset=utf-8",
+    ".js": "application/javascript; charset=utf-8",
+    ".json": "application/json; charset=utf-8",
+    ".svg": "image/svg+xml",
+    ".png": "image/png",
+}
+
+
+@dataclass
+class Response:
+    status_code: int
+    data: bytes
+    headers: Tuple[Tuple[str, str], ...]
+
+
+class TestClient:
+    def __init__(self, app: "TrafficSimulationApp") -> None:
+        self._app = app
+
+    def get(self, path: str) -> Response:
+        status, body, headers = self._app.handle_request("GET", path)
+        return Response(status, body, tuple(headers.items()))
+
+
+class TrafficSimulationApp:
+    def __init__(self) -> None:
+        self.root = Path(__file__).resolve().parent
+        self.template_path = self.root / "templates" / "index.html"
+        self.static_root = self.root / "static"
+
+    # Public API -----------------------------------------------------------------
+    def run(self, host: str = "127.0.0.1", port: int = 5000) -> None:
+        with make_server(host, port, self.wsgi_app) as server:
+            print(f"Serving traffic simulation on http://{host}:{port}")
+            try:
+                server.serve_forever()
+            except KeyboardInterrupt:
+                print("\nServer stopped")
+
+    def test_client(self) -> TestClient:
+        return TestClient(self)
+
+    # Internal request handling ---------------------------------------------------
+    def wsgi_app(self, environ, start_response):
+        method = environ.get("REQUEST_METHOD", "GET").upper()
+        path = unquote(environ.get("PATH_INFO", "/"))
+        status, body, headers = self.handle_request(method, path)
+        status_line = f"{status} {_STATUS_MAP.get(status, 'OK')}"
+        start_response(status_line, list(headers.items()))
+        return [body]
+
+    def handle_request(self, method: str, path: str) -> Tuple[int, bytes, dict[str, str]]:
+        if method not in {"GET", "HEAD"}:
+            return self._respond(405, b"Method Not Allowed", "text/plain; charset=utf-8")
+
+        if path in {"", "/"}:
+            body = self.template_path.read_bytes()
+            return self._respond(200, body, _MIME_MAP[".html"])
+
+        if path.startswith("/static/"):
+            return self._serve_static(path.removeprefix("/static/"))
+
+        return self._respond(404, b"Not Found", "text/plain; charset=utf-8")
+
+    def _serve_static(self, relative: str) -> Tuple[int, bytes, dict[str, str]]:
+        safe_parts = [part for part in Path(relative).parts if part not in {"..", "."}]
+        static_path = self.static_root.joinpath(*safe_parts)
+        if not static_path.is_file():
+            return self._respond(404, b"Not Found", "text/plain; charset=utf-8")
+        body = static_path.read_bytes()
+        mime = _MIME_MAP.get(static_path.suffix, "application/octet-stream")
+        return self._respond(200, body, mime)
+
+    def _respond(self, status: int, body: bytes, content_type: str) -> Tuple[int, bytes, dict[str, str]]:
+        headers = {"Content-Type": content_type, "Content-Length": str(len(body))}
+        return status, body, headers
+
+
+def create_app() -> TrafficSimulationApp:
+    return TrafficSimulationApp()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from . import create_app
+
+
+def run() -> None:
+    app = create_app()
+    app.run(host="0.0.0.0")
+
+
+if __name__ == "__main__":
+    run()

--- a/app/static/config/vehicleTypes.json
+++ b/app/static/config/vehicleTypes.json
@@ -1,0 +1,7 @@
+{
+  "vehicle_types": {
+    "car": { "color": "#3A7AFE", "avg_speed_mph": 32, "max_speed_mph": 70 },
+    "truck": { "color": "#EF4444", "avg_speed_mph": 24, "max_speed_mph": 60 },
+    "bike": { "color": "#10B981", "avg_speed_mph": 15, "max_speed_mph": 25 }
+  }
+}

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -1,0 +1,230 @@
+:root {
+  --bg: #0f172a;
+  --panel: rgba(15, 23, 42, 0.85);
+  --primary: #2563eb;
+  --primary-active: #1d4ed8;
+  --danger: #ef4444;
+  --danger-active: #dc2626;
+  --text: #f8fafc;
+  --muted: rgba(148, 163, 184, 0.85);
+  --halo: rgba(59, 130, 246, 0.4);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+html,
+body,
+#app {
+  height: 100%;
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+
+#map {
+  height: calc(100% - 80px);
+  width: 100%;
+  filter: saturate(0.85);
+}
+
+.control-bar {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  background: var(--panel);
+  backdrop-filter: blur(6px);
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.control-button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.6rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text);
+  cursor: pointer;
+  transition: transform 120ms ease, background 120ms ease, box-shadow 120ms ease;
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.35);
+}
+
+.control-button:focus-visible {
+  outline: 2px solid var(--text);
+  outline-offset: 2px;
+}
+
+.control-button.primary {
+  background: var(--primary);
+}
+
+.control-button.primary:hover {
+  background: var(--primary-active);
+  transform: translateY(-1px);
+}
+
+.control-button.danger {
+  background: var(--danger);
+}
+
+.control-button.danger.active {
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.35);
+}
+
+.control-button.danger:hover {
+  background: var(--danger-active);
+  transform: translateY(-1px);
+}
+
+.control-label {
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.control-input {
+  width: 90px;
+  padding: 0.45rem 0.65rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.65);
+  color: var(--text);
+  font-size: 1rem;
+}
+
+.control-input:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.legend {
+  position: absolute;
+  bottom: 120px;
+  right: 24px;
+  min-width: 220px;
+  padding: 1rem;
+  border-radius: 16px;
+  background: var(--panel);
+  box-shadow: 0 20px 30px rgba(15, 23, 42, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.legend-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.legend-chip {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  box-shadow: 0 0 0 3px rgba(15, 23, 42, 0.6);
+}
+
+#overlay-message {
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.75rem 1.25rem;
+  background: rgba(15, 23, 42, 0.9);
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  color: var(--text);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  box-shadow: 0 15px 30px rgba(15, 23, 42, 0.45);
+}
+
+.toast-visible {
+  position: absolute;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(15, 23, 42, 0.9);
+  color: var(--text);
+  padding: 0.65rem 1.25rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 20px 30px rgba(15, 23, 42, 0.45);
+  animation: toast-in 180ms ease;
+}
+
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translate(-50%, 12px);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+
+.vehicle-marker {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 2px solid rgba(15, 23, 42, 0.6);
+  box-shadow: 0 0 0 6px rgba(15, 23, 42, 0.2);
+}
+
+.vehicle-marker.paused {
+  animation: pulse 1s ease infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.2);
+  }
+}
+
+.block-overlay {
+  background: rgba(239, 68, 68, 0.45);
+  border-radius: 8px;
+  border: 1px solid rgba(239, 68, 68, 0.65);
+  box-shadow: 0 0 20px rgba(239, 68, 68, 0.35);
+}
+
+.block-overlay::after {
+  content: "";
+  position: absolute;
+  inset: -4px;
+  border-radius: inherit;
+  border: 1px dashed rgba(248, 113, 113, 0.8);
+}
+
+.segment-highlight {
+  filter: drop-shadow(0 0 6px var(--halo));
+}
+
+@media (max-width: 768px) {
+  #map {
+    height: calc(100% - 120px);
+  }
+
+  .control-bar {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .legend {
+    bottom: 140px;
+    right: 12px;
+    min-width: 180px;
+  }
+}

--- a/app/static/js/interactionHandler.js
+++ b/app/static/js/interactionHandler.js
@@ -1,0 +1,89 @@
+import { logger } from "./utils/logger.js";
+
+const INTERACTION_THRESHOLD_PX = 25;
+
+export class InteractionHandler {
+  constructor(mapViewer, overlayManager, vehicleEngine, uiControls) {
+    this.mapViewer = mapViewer;
+    this.map = mapViewer.map;
+    this.overlayManager = overlayManager;
+    this.vehicleEngine = vehicleEngine;
+    this.uiControls = uiControls;
+    this.carCount = Number(document.getElementById("car-count").value) || 1;
+    this.active = false;
+
+    this.pointerMove = this.onPointerMove.bind(this);
+    this.pointerClick = this.onPointerClick.bind(this);
+    this.contextMenu = (event) => event.originalEvent?.preventDefault?.();
+  }
+
+  setCarCount(count) {
+    this.carCount = Math.max(1, count);
+  }
+
+  enable() {
+    if (this.active) return;
+    this.active = true;
+    this.map.on("mousemove", this.pointerMove);
+    this.map.on("click", this.pointerClick);
+    this.map.on("contextmenu", this.pointerClick);
+    this.map.on("contextmenu", this.contextMenu);
+    this.map.getContainer().style.cursor = "not-allowed";
+  }
+
+  disable() {
+    if (!this.active) return;
+    this.active = false;
+    this.map.off("mousemove", this.pointerMove);
+    this.map.off("click", this.pointerClick);
+    this.map.off("contextmenu", this.pointerClick);
+    this.map.off("contextmenu", this.contextMenu);
+    this.overlayManager.highlightSegment(null);
+    this.map.getContainer().style.cursor = "grab";
+  }
+
+  onPointerMove(event) {
+    if (!this.overlayManager.hasSegments()) return;
+    const containerPoint = this.map.latLngToContainerPoint(event.latlng);
+    const match = this.overlayManager.findNearestSegment(containerPoint);
+    if (match && match.distance <= INTERACTION_THRESHOLD_PX) {
+      this.overlayManager.highlightSegment(match.segment.id);
+      this.map.getContainer().style.cursor = "pointer";
+    } else {
+      this.overlayManager.highlightSegment(null);
+      this.map.getContainer().style.cursor = "not-allowed";
+    }
+  }
+
+  onPointerClick(event) {
+    if (!this.overlayManager.hasSegments()) {
+      logger.warn("Ignoring click — overlay not ready");
+      return;
+    }
+    const containerPoint = this.map.latLngToContainerPoint(event.latlng);
+    const match = this.overlayManager.findNearestSegment(containerPoint);
+    if (!match || match.distance > INTERACTION_THRESHOLD_PX) {
+      this.uiControls.showToast("Click directly on a highlighted road segment");
+      return;
+    }
+
+    if (event.type === "contextmenu") {
+      this.handleBlock(match.segment.id);
+    } else {
+      this.handleVehicleSpawn(match, this.carCount);
+    }
+  }
+
+  handleVehicleSpawn(match, count) {
+    this.vehicleEngine.spawnVehicles(match, count);
+  }
+
+  handleBlock(segmentId) {
+    if (this.overlayManager.isSegmentBlocked(segmentId)) {
+      this.uiControls.showToast("Segment already blocked");
+      return;
+    }
+    this.overlayManager.addBlock(segmentId);
+    this.uiControls.showToast("Block placed — vehicles will stop");
+  }
+}

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -1,0 +1,137 @@
+import { MapViewer } from "./mapViewer.js";
+import { OverlayManager } from "./overlayManager.js";
+import { VehicleConfig } from "./vehicleConfig.js";
+import { UIControls } from "./uiControls.js";
+import { SimulationController, SimulationStates } from "./simController.js";
+import { VehicleEngine } from "./vehicleEngine.js";
+import { InteractionHandler } from "./interactionHandler.js";
+import { logger } from "./utils/logger.js";
+
+const mapViewer = new MapViewer();
+const overlayManager = new OverlayManager(mapViewer.map);
+const vehicleConfig = new VehicleConfig();
+const simulation = new SimulationController();
+let overlayBuilt = false;
+let preserveVehiclesOnStop = false;
+
+let interactions = null;
+
+const uiControls = new UIControls({
+  onRunToggle: () => handleRunToggle(),
+  onStop: () => handleStop(),
+  onCarCountChange: (value) => interactions?.setCarCount(value),
+});
+
+const vehicleEngine = new VehicleEngine(mapViewer, overlayManager, vehicleConfig);
+interactions = new InteractionHandler(mapViewer, overlayManager, vehicleEngine, uiControls);
+
+vehicleConfig.ready.then(() => {
+  uiControls.renderLegend(Array.from(vehicleConfig.getTypes().values()));
+});
+
+mapViewer.onZoomChange((radius) => {
+  if (overlayManager.hasSegments()) {
+    overlayManager.updateScreenPoints();
+  }
+  const showMessage = radius > 5 && (simulation.isIdle() || simulation.state === SimulationStates.STOPPED);
+  uiControls.showOverlayMessage(showMessage);
+});
+
+vehicleEngine.on("counts", (counts) => {
+  logger.debug("vehicle counts", counts);
+});
+
+vehicleEngine.on("idle", () => {
+  if (simulation.isRunning()) {
+    uiControls.showToast("All vehicles have exited the viewport");
+    preserveVehiclesOnStop = true;
+    simulation.stop();
+  }
+});
+
+vehicleEngine.on("jammed", () => {
+  if (simulation.isRunning()) {
+    uiControls.showToast("Traffic jam detected — simulation halted");
+    preserveVehiclesOnStop = true;
+    simulation.stop();
+  }
+});
+
+simulation.on("state", (state) => {
+  if (state === SimulationStates.RUNNING) {
+    uiControls.setRunState("running");
+  } else if (state === SimulationStates.PAUSED) {
+    uiControls.setRunState("paused");
+  } else {
+    uiControls.setRunState("idle");
+  }
+});
+
+simulation.on("start", () => {
+  vehicleEngine.start();
+});
+
+simulation.on("pause", () => {
+  vehicleEngine.pause();
+});
+
+simulation.on("resume", () => {
+  vehicleEngine.resume();
+});
+
+simulation.on("stop", () => {
+  vehicleEngine.stop(!preserveVehiclesOnStop);
+  interactions.disable();
+  preserveVehiclesOnStop = false;
+});
+
+uiControls.showOverlayMessage(!mapViewer.isWithinInteractionThreshold());
+
+async function ensureOverlay() {
+  if (overlayBuilt && overlayManager.hasSegments()) {
+    return true;
+  }
+  try {
+    uiControls.showToast("Loading roads for simulation…");
+    await overlayManager.buildOverlay();
+    overlayBuilt = true;
+    uiControls.showToast("Road overlay ready — click to add vehicles");
+    return true;
+  } catch (error) {
+    logger.error("Failed to build overlay", error);
+    uiControls.showToast("Unable to load roads — try again");
+    return false;
+  }
+}
+
+async function handleRunToggle() {
+  if (simulation.isRunning()) {
+    simulation.pause();
+    return;
+  }
+  if (simulation.isPaused()) {
+    simulation.resume();
+    return;
+  }
+  const withinThreshold = mapViewer.isWithinInteractionThreshold();
+  if (!withinThreshold) {
+    uiControls.showOverlayMessage(true);
+    uiControls.showToast("Zoom in closer to start the simulation");
+    return;
+  }
+  const overlayReady = await ensureOverlay();
+  if (!overlayReady) return;
+  mapViewer.freeze();
+  interactions.enable();
+  simulation.start();
+}
+
+function handleStop() {
+  if (simulation.state === SimulationStates.IDLE) return;
+  simulation.stop();
+  uiControls.showToast("Simulation stopped");
+}
+
+window.addEventListener("beforeunload", () => {
+  simulation.stop();
+});

--- a/app/static/js/mapViewer.js
+++ b/app/static/js/mapViewer.js
@@ -1,0 +1,74 @@
+import { logger } from "./utils/logger.js";
+
+const DEFAULT_CENTER = [37.7749, -122.4194];
+const DEFAULT_ZOOM = 14;
+const MAX_INTERACTION_RADIUS_MILES = 5;
+
+function metersToMiles(meters) {
+  return meters * 0.000621371;
+}
+
+export class MapViewer {
+  constructor() {
+    this.map = L.map("map", {
+      zoomControl: false,
+      minZoom: 5,
+      maxZoom: 19,
+    }).setView(DEFAULT_CENTER, DEFAULT_ZOOM);
+
+    L.control
+      .zoom({
+        position: "topright",
+      })
+      .addTo(this.map);
+
+    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      maxZoom: 19,
+      attribution: "&copy; OpenStreetMap contributors",
+    }).addTo(this.map);
+
+    this.zoomListeners = new Set();
+    this.map.on("zoomend", () => this.emitZoomChange());
+    this.map.on("moveend", () => this.emitZoomChange());
+  }
+
+  onZoomChange(listener) {
+    this.zoomListeners.add(listener);
+  }
+
+  emitZoomChange() {
+    const radiusMiles = this.getVisibleRadiusMiles();
+    this.zoomListeners.forEach((listener) => listener(radiusMiles));
+  }
+
+  getVisibleRadiusMiles() {
+    const bounds = this.map.getBounds();
+    const center = bounds.getCenter();
+    const north = bounds.getNorth();
+    const point = L.latLng(north, center.lng);
+    const meters = this.map.distance(center, point);
+    return metersToMiles(meters);
+  }
+
+  isWithinInteractionThreshold() {
+    const radius = this.getVisibleRadiusMiles();
+    logger.debug("visible radius", radius);
+    return radius <= MAX_INTERACTION_RADIUS_MILES;
+  }
+
+  freeze() {
+    this.map.dragging.disable();
+    this.map.scrollWheelZoom.disable();
+    this.map.doubleClickZoom.disable();
+    this.map.boxZoom.disable();
+    this.map.keyboard.disable();
+  }
+
+  unfreeze() {
+    this.map.dragging.enable();
+    this.map.scrollWheelZoom.enable();
+    this.map.doubleClickZoom.enable();
+    this.map.boxZoom.enable();
+    this.map.keyboard.enable();
+  }
+}

--- a/app/static/js/overlayManager.js
+++ b/app/static/js/overlayManager.js
@@ -1,0 +1,246 @@
+import { logger } from "./utils/logger.js";
+import { distancePointToPolyline } from "./utils/geoUtils.js";
+
+const HIGHWAY_CLASSES = [
+  "motorway",
+  "trunk",
+  "primary",
+  "secondary",
+  "tertiary",
+  "residential",
+  "living_street",
+  "service",
+];
+
+const STYLES = {
+  motorway: { color: "#e2e8f0", weight: 8 },
+  trunk: { color: "#cbd5f5", weight: 7 },
+  primary: { color: "#aebbf5", weight: 6 },
+  secondary: { color: "#8fa5f5", weight: 5 },
+  tertiary: { color: "#7c93f5", weight: 4 },
+  residential: { color: "#64748b", weight: 3.5 },
+  living_street: { color: "#475569", weight: 3 },
+  service: { color: "#475569", weight: 3 },
+  default: { color: "#64748b", weight: 3 },
+};
+
+function getStyle(highway) {
+  return STYLES[highway] || STYLES.default;
+}
+
+export class OverlayManager {
+  constructor(map) {
+    this.map = map;
+    this.segments = new Map();
+    this.blocks = new Map();
+    this.blockedSegments = new Set();
+    this.highlighted = null;
+    this.adjacency = new Map();
+  }
+
+  hasSegments() {
+    return this.segments.size > 0;
+  }
+
+  async buildOverlay() {
+    const bounds = this.map.getBounds();
+    const bbox = `${bounds.getSouth()},${bounds.getWest()},${bounds.getNorth()},${bounds.getEast()}`;
+    const query = `[
+      out:json;
+      way["highway"](${bbox});
+      (._;>;);
+      out;`;
+    const endpoint = "https://overpass-api.de/api/interpreter";
+
+    logger.info("Requesting overlay", bbox);
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ data: query }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch overlay: ${response.status}`);
+    }
+
+    const data = await response.json();
+    this.ingestOverpassData(data);
+    this.renderSegments();
+  }
+
+  ingestOverpassData(data) {
+    const nodes = new Map();
+    data.elements
+      .filter((el) => el.type === "node")
+      .forEach((node) => nodes.set(node.id, { lat: node.lat, lng: node.lon }));
+
+    const segmentEntries = [];
+
+    data.elements
+      .filter((el) => el.type === "way" && HIGHWAY_CLASSES.includes(el.tags.highway))
+      .forEach((way) => {
+        const latlngs = way.nodes
+          .map((nodeId) => nodes.get(nodeId))
+          .filter(Boolean);
+        if (latlngs.length < 2) {
+          return;
+        }
+        const id = String(way.id);
+        const style = getStyle(way.tags.highway);
+        const cumulativeLengths = [0];
+        for (let i = 1; i < latlngs.length; i += 1) {
+          const prev = latlngs[i - 1];
+          const curr = latlngs[i];
+          const length = this.map.distance(prev, curr);
+          cumulativeLengths.push(cumulativeLengths[i - 1] + length);
+        }
+        const polyline = L.polyline(latlngs, {
+          color: style.color,
+          weight: style.weight,
+          opacity: 0.85,
+          pane: "overlayPane",
+          interactive: false,
+        });
+        this.segments.set(id, {
+          id,
+          highway: way.tags.highway,
+          latlngs,
+          polyline,
+          screenPoints: [],
+          baseStyle: style,
+          cumulativeLengths,
+          totalLength: cumulativeLengths[cumulativeLengths.length - 1] ?? 0,
+        });
+        segmentEntries.push(this.segments.get(id));
+      });
+
+    this.buildGraph(segmentEntries);
+  }
+
+  buildGraph(segments) {
+    this.adjacency.clear();
+    segments.forEach((segment) => {
+      const start = segment.latlngs[0];
+      const end = segment.latlngs[segment.latlngs.length - 1];
+      const startKey = this.nodeKey(start);
+      const endKey = this.nodeKey(end);
+      segment.terminals = { startKey, endKey };
+
+      if (!this.adjacency.has(startKey)) this.adjacency.set(startKey, []);
+      if (!this.adjacency.has(endKey)) this.adjacency.set(endKey, []);
+      this.adjacency.get(startKey).push({ segmentId: segment.id, direction: 1 });
+      this.adjacency.get(endKey).push({ segmentId: segment.id, direction: -1 });
+    });
+  }
+
+  nodeKey({ lat, lng }) {
+    return `${lat.toFixed(5)}|${lng.toFixed(5)}`;
+  }
+
+  renderSegments() {
+    this.layerGroup?.remove();
+    this.layerGroup = L.layerGroup();
+    this.segments.forEach((segment) => {
+      segment.polyline.addTo(this.layerGroup);
+    });
+    this.layerGroup.addTo(this.map);
+    this.updateScreenPoints();
+  }
+
+  updateScreenPoints() {
+    this.segments.forEach((segment) => {
+      segment.screenPoints = segment.latlngs.map((latlng) =>
+        this.map.latLngToContainerPoint(latlng)
+      );
+    });
+  }
+
+  highlightSegment(segmentId) {
+    if (this.highlighted && this.highlighted !== segmentId) {
+      const existing = this.segments.get(this.highlighted);
+      if (existing) {
+        existing.polyline.setStyle({
+          weight: existing.baseStyle.weight,
+          opacity: 0.85,
+        });
+      }
+    }
+    if (!segmentId) {
+      if (this.highlighted) {
+        const existing = this.segments.get(this.highlighted);
+        if (existing) {
+          existing.polyline.setStyle({
+            weight: existing.baseStyle.weight,
+            opacity: 0.85,
+          });
+        }
+      }
+      this.highlighted = null;
+      return;
+    }
+    const segment = this.segments.get(segmentId);
+    if (!segment) return;
+    segment.polyline.setStyle({
+      weight: segment.baseStyle.weight + 2,
+      opacity: 1,
+    });
+    this.highlighted = segmentId;
+  }
+
+  addBlock(segmentId) {
+    const segment = this.segments.get(segmentId);
+    if (!segment) return null;
+    const blockId = `${segmentId}-${Date.now()}`;
+    const bounds = L.latLngBounds(segment.latlngs);
+    const block = L.rectangle(bounds, {
+      className: "block-overlay",
+      interactive: false,
+    }).addTo(this.map);
+    this.blocks.set(blockId, { segmentId, block });
+    this.blockedSegments.add(segmentId);
+    return blockId;
+  }
+
+  clearBlocks() {
+    this.blocks.forEach(({ block }) => block.remove());
+    this.blocks.clear();
+    this.blockedSegments.clear();
+  }
+
+  clear() {
+    this.layerGroup?.remove();
+    this.layerGroup = null;
+    this.segments.clear();
+    this.clearBlocks();
+    this.adjacency.clear();
+  }
+
+  isSegmentBlocked(segmentId) {
+    return this.blockedSegments.has(segmentId);
+  }
+
+  getSegment(segmentId) {
+    return this.segments.get(segmentId);
+  }
+
+  getConnectedSegments(nodeKey, excludeId) {
+    const options = this.adjacency.get(nodeKey);
+    if (!options) return [];
+    return options.filter((entry) => entry.segmentId !== excludeId);
+  }
+
+  findNearestSegment(point) {
+    this.updateScreenPoints();
+    let best = null;
+    let minDist = Infinity;
+    this.segments.forEach((segment) => {
+      if (segment.screenPoints.length < 2) return;
+      const result = distancePointToPolyline(point, segment.screenPoints);
+      if (result.distance < minDist) {
+        minDist = result.distance;
+        best = { segment, result };
+      }
+    });
+    return best && { segment: best.segment, ...best.result, distance: minDist };
+  }
+}

--- a/app/static/js/simController.js
+++ b/app/static/js/simController.js
@@ -1,0 +1,72 @@
+import { logger } from "./utils/logger.js";
+
+const STATES = {
+  IDLE: "idle",
+  RUNNING: "running",
+  PAUSED: "paused",
+  STOPPED: "stopped",
+};
+
+export class SimulationController {
+  constructor() {
+    this.state = STATES.IDLE;
+    this.listeners = new Map();
+  }
+
+  on(event, callback) {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+    this.listeners.get(event).add(callback);
+  }
+
+  emit(event, payload) {
+    this.listeners.get(event)?.forEach((callback) => callback(payload));
+  }
+
+  setState(nextState) {
+    if (this.state === nextState) return;
+    logger.debug(`state transition ${this.state} → ${nextState}`);
+    this.state = nextState;
+    this.emit("state", nextState);
+  }
+
+  start() {
+    this.setState(STATES.RUNNING);
+    this.emit("start");
+  }
+
+  pause() {
+    this.setState(STATES.PAUSED);
+    this.emit("pause");
+  }
+
+  resume() {
+    this.setState(STATES.RUNNING);
+    this.emit("resume");
+  }
+
+  stop() {
+    this.setState(STATES.STOPPED);
+    this.emit("stop");
+  }
+
+  reset() {
+    this.setState(STATES.IDLE);
+    this.emit("reset");
+  }
+
+  isRunning() {
+    return this.state === STATES.RUNNING;
+  }
+
+  isIdle() {
+    return this.state === STATES.IDLE;
+  }
+
+  isPaused() {
+    return this.state === STATES.PAUSED;
+  }
+}
+
+export { STATES as SimulationStates };

--- a/app/static/js/uiControls.js
+++ b/app/static/js/uiControls.js
@@ -1,0 +1,82 @@
+import { logger } from "./utils/logger.js";
+
+export class UIControls {
+  constructor({ onRunToggle, onStop, onCarCountChange }) {
+    this.runButton = document.getElementById("run-toggle");
+    this.stopButton = document.getElementById("stop");
+    this.carInput = document.getElementById("car-count");
+    this.toast = document.getElementById("toast");
+    this.overlayMessage = document.getElementById("overlay-message");
+
+    this.runState = "idle";
+
+    this.runButton.addEventListener("click", () => onRunToggle());
+    this.stopButton.addEventListener("click", () => onStop());
+    this.carInput.addEventListener("change", () => {
+      const value = Math.max(1, Math.floor(Number(this.carInput.value) || 1));
+      this.carInput.value = value;
+      onCarCountChange(value);
+    });
+
+    document.addEventListener("keydown", (event) => {
+      if (event.code === "Space" && document.activeElement === this.runButton) {
+        event.preventDefault();
+        onRunToggle();
+      }
+      if (event.code === "Enter" && document.activeElement === this.stopButton) {
+        onStop();
+      }
+    });
+  }
+
+  setRunState(state) {
+    this.runState = state;
+    if (state === "running") {
+      this.runButton.textContent = "⏸️ Pause";
+      this.stopButton.classList.add("active");
+    } else if (state === "paused") {
+      this.runButton.textContent = "▶️ Resume";
+      this.stopButton.classList.add("active");
+    } else {
+      this.runButton.textContent = "▶️ Run";
+      this.stopButton.classList.remove("active");
+    }
+  }
+
+  showOverlayMessage(show) {
+    this.overlayMessage.hidden = !show;
+  }
+
+  showToast(message) {
+    logger.info("toast", message);
+    this.toast.textContent = message;
+    this.toast.hidden = false;
+    this.toast.classList.add("toast-visible");
+    clearTimeout(this.toastTimeout);
+    this.toastTimeout = setTimeout(() => {
+      this.toast.hidden = true;
+      this.toast.classList.remove("toast-visible");
+    }, 2800);
+  }
+
+  renderLegend(vehicleTypes) {
+    const legend = document.getElementById("legend");
+    legend.innerHTML = "";
+    const title = document.createElement("div");
+    title.className = "legend-title";
+    title.textContent = "Vehicle Types";
+    legend.appendChild(title);
+    vehicleTypes.forEach((type) => {
+      const row = document.createElement("div");
+      row.className = "legend-item";
+      const chip = document.createElement("span");
+      chip.className = "legend-chip";
+      chip.style.backgroundColor = type.color;
+      const label = document.createElement("span");
+      label.textContent = `${type.name} — avg ${Math.round(type.avgSpeedMps / 0.44704)} mph`;
+      row.appendChild(chip);
+      row.appendChild(label);
+      legend.appendChild(row);
+    });
+  }
+}

--- a/app/static/js/utils/geoUtils.js
+++ b/app/static/js/utils/geoUtils.js
@@ -1,0 +1,66 @@
+export function haversineDistance(latlngA, latlngB) {
+  const R = 6371000;
+  const toRad = (deg) => (deg * Math.PI) / 180;
+  const dLat = toRad(latlngB.lat - latlngA.lat);
+  const dLng = toRad(latlngB.lng - latlngA.lng);
+  const lat1 = toRad(latlngA.lat);
+  const lat2 = toRad(latlngB.lat);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) * Math.sin(dLng / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}
+
+export function polylineLength(points) {
+  if (points.length < 2) return 0;
+  let total = 0;
+  for (let i = 1; i < points.length; i += 1) {
+    total += haversineDistance(points[i - 1], points[i]);
+  }
+  return total;
+}
+
+export function distancePointToSegment(point, a, b) {
+  const apx = point.x - a.x;
+  const apy = point.y - a.y;
+  const abx = b.x - a.x;
+  const aby = b.y - a.y;
+  const ab2 = abx * abx + aby * aby;
+  const dot = apx * abx + apy * aby;
+  const t = ab2 !== 0 ? Math.max(0, Math.min(1, dot / ab2)) : 0;
+  const closest = { x: a.x + abx * t, y: a.y + aby * t };
+  const dx = point.x - closest.x;
+  const dy = point.y - closest.y;
+  return { distance: Math.hypot(dx, dy), t, closest };
+}
+
+export function distancePointToPolyline(point, polyline) {
+  let closestSegment = null;
+  let minDist = Infinity;
+  let accumLength = 0;
+  let tAlong = 0;
+
+  for (let i = 1; i < polyline.length; i += 1) {
+    const a = polyline[i - 1];
+    const b = polyline[i];
+    const { distance, t } = distancePointToSegment(point, a, b);
+    if (distance < minDist) {
+      minDist = distance;
+      closestSegment = { index: i - 1, tOnSegment: t };
+      tAlong = accumLength + t;
+    }
+    accumLength += 1;
+  }
+
+  return {
+    distance: minDist,
+    segmentIndex: closestSegment?.index ?? 0,
+    t: tAlong,
+    tOnSegment: closestSegment?.tOnSegment ?? 0,
+  };
+}
+
+export function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}

--- a/app/static/js/utils/logger.js
+++ b/app/static/js/utils/logger.js
@@ -1,0 +1,16 @@
+const LEVELS = ["debug", "info", "warn", "error"];
+const activeLevel = LEVELS.indexOf(
+  (window.localStorage.getItem("traffic-sim-log-level") || "warn").toLowerCase()
+);
+
+function shouldLog(level) {
+  const idx = LEVELS.indexOf(level);
+  return idx >= activeLevel;
+}
+
+export const logger = {
+  debug: (...args) => shouldLog("debug") && console.debug("[traffic]", ...args),
+  info: (...args) => shouldLog("info") && console.info("[traffic]", ...args),
+  warn: (...args) => shouldLog("warn") && console.warn("[traffic]", ...args),
+  error: (...args) => shouldLog("error") && console.error("[traffic]", ...args),
+};

--- a/app/static/js/vehicleConfig.js
+++ b/app/static/js/vehicleConfig.js
@@ -1,0 +1,48 @@
+import { logger } from "./utils/logger.js";
+
+async function fetchConfig() {
+  const response = await fetch("/static/config/vehicleTypes.json");
+  if (!response.ok) {
+    throw new Error(`Unable to load vehicle config (${response.status})`);
+  }
+  return response.json();
+}
+
+export class VehicleConfig {
+  constructor() {
+    this.types = new Map();
+    this.ready = this.load();
+  }
+
+  async load() {
+    try {
+      const data = await fetchConfig();
+      Object.entries(data.vehicle_types || {}).forEach(([name, value]) => {
+        this.types.set(name, {
+          name,
+          color: value.color,
+          avgSpeedMps: (value.avg_speed_mph || 25) * 0.44704,
+          maxSpeedMps: (value.max_speed_mph || value.avg_speed_mph || 35) * 0.44704,
+        });
+      });
+      if (!this.types.size) {
+        throw new Error("Vehicle config empty");
+      }
+      return this.types;
+    } catch (error) {
+      logger.error("Failed to load vehicle config", error);
+      const fallback = new Map([
+        [
+          "car",
+          { name: "car", color: "#3A7AFE", avgSpeedMps: 30 * 0.44704, maxSpeedMps: 65 * 0.44704 },
+        ],
+      ]);
+      this.types = fallback;
+      return fallback;
+    }
+  }
+
+  getTypes() {
+    return this.types;
+  }
+}

--- a/app/static/js/vehicleEngine.js
+++ b/app/static/js/vehicleEngine.js
@@ -1,0 +1,290 @@
+import { logger } from "./utils/logger.js";
+import { clamp } from "./utils/geoUtils.js";
+
+function randomChoice(items) {
+  if (!items.length) return null;
+  const idx = Math.floor(Math.random() * items.length);
+  return items[idx];
+}
+
+export class VehicleEngine {
+  constructor(mapViewer, overlayManager, vehicleConfig) {
+    this.mapViewer = mapViewer;
+    this.map = mapViewer.map;
+    this.overlayManager = overlayManager;
+    this.vehicleConfig = vehicleConfig;
+    this.vehicles = new Map();
+    this.vehicleId = 0;
+    this.running = false;
+    this.paused = false;
+    this.lastTimestamp = null;
+    this.animationFrame = null;
+    this.listeners = new Map();
+    this.typeIterator = null;
+    this.hasActiveVehicles = false;
+  }
+
+  on(event, callback) {
+    if (!this.listeners.has(event)) this.listeners.set(event, new Set());
+    this.listeners.get(event).add(callback);
+  }
+
+  emit(event, payload) {
+    this.listeners.get(event)?.forEach((callback) => callback(payload));
+  }
+
+  iterateTypes() {
+    const types = Array.from(this.vehicleConfig.getTypes().values());
+    if (!types.length) return null;
+    if (!this.typeIterator || this.typeIterator.index >= types.length) {
+      this.typeIterator = { index: 0, types };
+    }
+    const type = this.typeIterator.types[this.typeIterator.index % types.length];
+    this.typeIterator.index += 1;
+    return type;
+  }
+
+  spawnVehicles(segmentResult, count) {
+    if (!segmentResult) return;
+    const { segment, segmentIndex, tOnSegment } = segmentResult;
+    const types = Array.from(this.vehicleConfig.getTypes().values());
+    if (!types.length) {
+      logger.warn("No vehicle types available");
+      return;
+    }
+    for (let i = 0; i < count; i += 1) {
+      const type = this.iterateTypes() || randomChoice(types);
+      const vehicleId = `vehicle-${this.vehicleId += 1}`;
+      const direction = 1;
+      const baseDistance = this.distanceAt(segment, segmentIndex, tOnSegment);
+      const jitter = (Math.random() * 8 - 4) * i;
+      const initialDistance = clamp(baseDistance + jitter, 0, segment.totalLength);
+      const marker = L.circleMarker(segment.latlngs[segmentIndex], {
+        radius: 6,
+        weight: 2,
+        color: "#0f172a",
+        fillColor: type.color,
+        fillOpacity: 1,
+        pane: "markerPane",
+      }).addTo(this.map);
+      marker.getElement()?.classList.add("vehicle-marker");
+      const vehicle = {
+        id: vehicleId,
+        type,
+        segmentId: segment.id,
+        direction,
+        distance: initialDistance,
+        speedMps: clamp(type.avgSpeedMps * (0.85 + Math.random() * 0.3), 1, type.maxSpeedMps),
+        status: "active",
+        marker,
+      };
+      this.vehicles.set(vehicleId, vehicle);
+      this.updateMarkerPosition(vehicle);
+    }
+    this.hasActiveVehicles = true;
+    this.emitCounts();
+    this.ensureLoop();
+  }
+
+  distanceAt(segment, segmentIndex, tOnSegment) {
+    const clampedIndex = clamp(segmentIndex, 0, segment.cumulativeLengths.length - 2);
+    const startDistance = segment.cumulativeLengths[clampedIndex];
+    const segmentLength =
+      segment.cumulativeLengths[clampedIndex + 1] - segment.cumulativeLengths[clampedIndex];
+    return startDistance + segmentLength * clamp(tOnSegment, 0, 1);
+  }
+
+  ensureLoop() {
+    if (this.animationFrame) return;
+    this.running = true;
+    const loop = (timestamp) => {
+      if (!this.running) return;
+      if (!this.lastTimestamp) this.lastTimestamp = timestamp;
+      const delta = (timestamp - this.lastTimestamp) / 1000;
+      this.lastTimestamp = timestamp;
+      if (!this.paused) {
+        this.update(delta);
+      }
+      this.animationFrame = requestAnimationFrame(loop);
+    };
+    this.animationFrame = requestAnimationFrame(loop);
+  }
+
+  start() {
+    this.running = true;
+    this.paused = false;
+    this.lastTimestamp = null;
+    this.vehicles.forEach((vehicle) => vehicle.marker.getElement()?.classList.remove("paused"));
+    this.ensureLoop();
+  }
+
+  pause() {
+    this.paused = true;
+    this.vehicles.forEach((vehicle) => vehicle.marker.getElement()?.classList.add("paused"));
+  }
+
+  resume() {
+    this.paused = false;
+    this.lastTimestamp = null;
+    this.vehicles.forEach((vehicle) => vehicle.marker.getElement()?.classList.remove("paused"));
+  }
+
+  stop(clearVehicles = true) {
+    this.running = false;
+    this.paused = false;
+    if (this.animationFrame) cancelAnimationFrame(this.animationFrame);
+    this.animationFrame = null;
+    this.lastTimestamp = null;
+    if (clearVehicles) {
+      this.clearVehicles();
+    } else {
+      this.vehicles.forEach((vehicle) => {
+        vehicle.marker.getElement()?.classList.add("paused");
+      });
+      this.emitCounts();
+    }
+  }
+
+  clearVehicles() {
+    this.vehicles.forEach((vehicle) => vehicle.marker.remove());
+    this.vehicles.clear();
+    this.hasActiveVehicles = false;
+    this.emitCounts();
+  }
+
+  update(delta) {
+    if (delta <= 0) return;
+    const bounds = this.map.getBounds().pad(0.2);
+    this.vehicles.forEach((vehicle) => {
+      if (vehicle.status === "exited") return;
+      if (vehicle.status === "blocked") {
+        if (!this.overlayManager.isSegmentBlocked(vehicle.segmentId)) {
+          vehicle.status = "active";
+          vehicle.marker.getElement()?.classList.remove("paused");
+        } else {
+          return;
+        }
+      }
+      if (this.overlayManager.isSegmentBlocked(vehicle.segmentId)) {
+        vehicle.status = "blocked";
+        vehicle.marker.getElement()?.classList.add("paused");
+        return;
+      }
+
+      let remaining = vehicle.speedMps * delta;
+      while (remaining > 0 && vehicle.status === "active") {
+        const segment = this.overlayManager.getSegment(vehicle.segmentId);
+        if (!segment) {
+          vehicle.status = "exited";
+          break;
+        }
+        const targetDistance = vehicle.direction === 1 ? segment.totalLength : 0;
+        const distanceToTarget = Math.abs(targetDistance - vehicle.distance);
+        if (distanceToTarget > remaining) {
+          vehicle.distance += vehicle.direction * remaining;
+          remaining = 0;
+        } else {
+          vehicle.distance = targetDistance;
+          remaining -= distanceToTarget;
+          const transitioned = this.advanceToNextSegment(vehicle);
+          if (!transitioned) {
+            vehicle.status = "exited";
+            break;
+          }
+        }
+      }
+
+      if (vehicle.status === "exited") {
+        vehicle.marker.remove();
+        this.vehicles.delete(vehicle.id);
+        return;
+      }
+
+      const segment = this.overlayManager.getSegment(vehicle.segmentId);
+      if (!segment) {
+        vehicle.marker.remove();
+        this.vehicles.delete(vehicle.id);
+        return;
+      }
+
+      this.updateMarkerPosition(vehicle);
+      if (!bounds.contains(vehicle.marker.getLatLng())) {
+        vehicle.marker.remove();
+        this.vehicles.delete(vehicle.id);
+      }
+    });
+
+    this.emitCounts();
+  }
+
+  advanceToNextSegment(vehicle) {
+    const segment = this.overlayManager.getSegment(vehicle.segmentId);
+    if (!segment) return false;
+    const nodeKey = vehicle.direction === 1 ? segment.terminals.endKey : segment.terminals.startKey;
+    const candidates = this.overlayManager
+      .getConnectedSegments(nodeKey, vehicle.segmentId)
+      .filter((candidate) => !this.overlayManager.isSegmentBlocked(candidate.segmentId));
+    const next = randomChoice(candidates);
+    if (!next) {
+      return false;
+    }
+    const nextSegment = this.overlayManager.getSegment(next.segmentId);
+    if (!nextSegment) {
+      return false;
+    }
+    vehicle.segmentId = next.segmentId;
+    vehicle.direction = next.direction;
+    vehicle.distance = next.direction === 1 ? 0 : nextSegment.totalLength;
+    return true;
+  }
+
+  updateMarkerPosition(vehicle) {
+    const segment = this.overlayManager.getSegment(vehicle.segmentId);
+    if (!segment) return;
+    const distance = clamp(vehicle.distance, 0, segment.totalLength);
+    const latlng = this.latLngAtDistance(segment, distance);
+    vehicle.marker.setLatLng(latlng);
+  }
+
+  latLngAtDistance(segment, distance) {
+    const target = clamp(distance, 0, segment.totalLength);
+    const cumulative = segment.cumulativeLengths;
+    let index = 1;
+    while (index < cumulative.length && cumulative[index] < target) {
+      index += 1;
+    }
+    index = clamp(index, 1, cumulative.length - 1);
+    const prevPoint = segment.latlngs[index - 1];
+    const nextPoint = segment.latlngs[index];
+    const startDistance = cumulative[index - 1];
+    const segmentLength = cumulative[index] - startDistance;
+    const ratio = segmentLength === 0 ? 0 : (target - startDistance) / segmentLength;
+    const lat = prevPoint.lat + (nextPoint.lat - prevPoint.lat) * ratio;
+    const lng = prevPoint.lng + (nextPoint.lng - prevPoint.lng) * ratio;
+    return L.latLng(lat, lng);
+  }
+
+  emitCounts() {
+    const counts = { active: 0, blocked: 0, exited: 0 };
+    this.vehicles.forEach((vehicle) => {
+      counts[vehicle.status] = (counts[vehicle.status] || 0) + 1;
+    });
+    counts.total = this.vehicles.size;
+    this.emit("counts", counts);
+    const hadVehicles = this.hasActiveVehicles;
+    if (counts.total === 0) {
+      this.hasActiveVehicles = false;
+      if (this.running && hadVehicles) {
+        this.emit("idle");
+      }
+      return;
+    }
+    this.hasActiveVehicles = true;
+    if (!this.running) {
+      return;
+    }
+    if (counts.active === 0) {
+      this.emit("jammed");
+    }
+  }
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Traffic Simulation</title>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+      crossorigin=""
+    />
+    <link rel="stylesheet" href="/static/css/styles.css" />
+  </head>
+  <body>
+    <div id="app">
+      <div id="map" aria-label="Traffic simulation map"></div>
+      <div id="overlay-message" role="alert" hidden>Zoom in further to enable the simulation.</div>
+      <div id="controls" class="control-bar" aria-label="Simulation controls">
+        <button id="run-toggle" class="control-button primary" type="button">▶️ Run</button>
+        <button id="stop" class="control-button danger" type="button">🛑 Stop</button>
+        <label class="control-label" for="car-count">Car Count:</label>
+        <input id="car-count" class="control-input" type="number" min="1" value="3" aria-label="Number of vehicles to add" />
+      </div>
+      <div id="legend" class="legend" aria-live="polite"></div>
+      <div id="toast" role="status" aria-live="assertive" hidden></div>
+    </div>
+    <script
+      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+      integrity="sha256-SmSRN8fM0tNvk9oPjiYPO2wT7GN+VDYVxC54JfDgFkA="
+      crossorigin=""
+    ></script>
+    <script type="module" src="/static/js/main.js"></script>
+  </body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# No third-party dependencies are required for this project.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,9 @@
+from app import create_app
+
+
+def test_index_route():
+    app = create_app()
+    client = app.test_client()
+    response = client.get("/")
+    assert response.status_code == 200
+    assert b"Traffic Simulation" in response.data


### PR DESCRIPTION
## Summary
- implement a lightweight Python WSGI server that serves the traffic simulation UI and static assets
- add Leaflet-driven overlay, vehicle engine, interaction handling, and configurable vehicle types for the simulation
- refresh styling, documentation, and add a pytest smoke test for the homepage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de93cda7f08330a6b134f05cf07f5e